### PR TITLE
Checking that target id in alignment is not -1

### DIFF
--- a/hts/bam.py
+++ b/hts/bam.py
@@ -126,7 +126,11 @@ class Alignment(object):
     def tname(self):
         """Chromosome or sequence aligned to."""
         tid = self._b.core.tid
+        if tid == -1:  # Read is unaligned, have no target
+            return None
+
         return ffi.string(self._h.target_name[tid])
+
     target = tname
 
     @property


### PR DESCRIPTION
Accessing target name for unaligned records would yield segmentation fault since `tname` would try to look up element `-1` in the `target_name` list.

Now `None` is returned in stead.